### PR TITLE
Convert .gitmodule paths from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,16 +1,16 @@
 [submodule "third-party/DinguxCommander"]
 	path = third-party/DinguxCommander
-	url = git@github.com:shauninman/DinguxCommander.git
+	url = https://github.com/shauninman/DinguxCommander.git
 	branch = miniui-miyoomini
 [submodule "third-party/SDL-1.2"]
 	path = third-party/SDL-1.2
-	url = git@github.com:shauninman/SDL-1.2.git
+	url = https://github.com/shauninman/SDL-1.2.git
 	branch = miniui-miyoomini
 [submodule "third-party/picoarch"]
 	path = third-party/picoarch
-	url = git@github.com:shauninman/picoarch.git
+	url = https://github.com/shauninman/picoarch.git
 	branch = miniui-miyoomini
 [submodule "third-party/vvvvvv"]
 	path = third-party/vvvvvv
-	url = git@github.com:shauninman/VVVVVV.git
+	url = https://github.com/shauninman/VVVVVV.git
 	branch = miniui-miyoomini


### PR DESCRIPTION
The SSH format prevents people from building the code without private key access to the repo